### PR TITLE
Dockerfile: build complete rootfs in builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN wget -q -O- https://buildroot.org/downloads/buildroot-$BR_VERSION.tar.gz | t
 
 COPY config.$TARGET_ARCH .config 
 
-RUN make olddefconfig && make toolchain
+RUN make olddefconfig && make


### PR DESCRIPTION
Buildroot builds its own toolchain for a given host and target before
building applications and the desired rootfs. Using "make toolchain"
builds only the toolchain, ignoring many common applications and
libraries that may be shared between systems.

Remove the target building only the toolchain so that we build a
complete minimal system, cutting down on build time.