### PR TITLE
README: change to multiple repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ docker build . --target base -t buildroot-base
 ### build the rootfs images for your host
 
 ```bash
-docker build . --build-arg TARGET_ARCH=amd64    -t buildroot-base:amd64-rootfs
-docker build . --build-arg TARGET_ARCH=aarch64  -t buildroot-base:aarch64-rootfs
-docker build . --build-arg TARGET_ARCH=armv6hf  -t buildroot-base:armv6hf-rootfs
-docker build . --build-arg TARGET_ARCH=armv7hf  -t buildroot-base:armv7hf-rootfs
-docker build . --build-arg TARGET_ARCH=rpi      -t buildroot-base:rpi-rootfs
+docker build . --build-arg TARGET_ARCH=amd64    -t buildroot-rootfs-amd64
+docker build . --build-arg TARGET_ARCH=aarch64  -t buildroot-rootfs-aarch64
+docker build . --build-arg TARGET_ARCH=armv6hf  -t buildroot-rootfs-armv6hf
+docker build . --build-arg TARGET_ARCH=armv7hf  -t buildroot-rootfs-armv7hf
+docker build . --build-arg TARGET_ARCH=rpi      -t buildroot-rootfs-rpi
 ```
 
 ## push
@@ -42,8 +42,11 @@ docker buildx create --use --driver docker-container
 ```bash
 docker buildx build . \
     --platform linux/amd64,linux/arm64 \
+    --build-arg BR_VERSION=2020.08.2 \
     --target base \
-    --push -t klutchell/buildroot-base:latest
+    -t klutchell/buildroot-base:2020.08.2 \
+    -t klutchell/buildroot-base:latest \
+    --push
 ```
 
 ### build and push multiarch rootfs images
@@ -53,28 +56,43 @@ Go get a coffee, these could take hours.
 ```bash
 docker buildx build . \
     --platform linux/amd64,linux/arm64 \
+    --build-arg BR_VERSION=2020.08.2 \
     --build-arg TARGET_ARCH=amd64 \
-    --push -t klutchell/buildroot-base:amd64-rootfs
+    -t klutchell/buildroot-rootfs-amd64:2020.08.2 \
+    -t klutchell/buildroot-rootfs-amd64:latest \
+    --push 
 
 docker buildx build . \
     --platform linux/amd64,linux/arm64 \
+    --build-arg BR_VERSION=2020.08.2 \
     --build-arg TARGET_ARCH=aarch64 \
-    --push -t klutchell/buildroot-base:aarch64-rootfs
+    -t klutchell/buildroot-rootfs-aarch64:2020.08.2 \
+    -t klutchell/buildroot-rootfs-aarch64:latest \
+    --push 
 
 docker buildx build . \
     --platform linux/amd64,linux/arm64 \
+    --build-arg BR_VERSION=2020.08.2 \
     --build-arg TARGET_ARCH=armv6hf \
-    --push -t klutchell/buildroot-base:armv6hf-rootfs
+    -t klutchell/buildroot-rootfs-armv6hf:2020.08.2 \
+    -t klutchell/buildroot-rootfs-armv6hf:latest \
+    --push 
 
 docker buildx build . \
     --platform linux/amd64,linux/arm64 \
+    --build-arg BR_VERSION=2020.08.2 \
     --build-arg TARGET_ARCH=armv7hf \
-    --push -t klutchell/buildroot-base:armv7hf-rootfs
+    -t klutchell/buildroot-rootfs-armv7hf:2020.08.2 \
+    -t klutchell/buildroot-rootfs-armv7hf:latest \
+    --push 
 
 docker buildx build . \
     --platform linux/amd64,linux/arm64 \
+    --build-arg BR_VERSION=2020.08.2 \
     --build-arg TARGET_ARCH=rpi \
-    --push -t klutchell/buildroot-base:rpi-rootfs
+    -t klutchell/buildroot-rootfs-rpi:2020.08.2 \
+    -t klutchell/buildroot-rootfs-rpi:latest \
+    --push 
 ```
 
 ## examples
@@ -90,6 +108,7 @@ Before building examples follow the instructions above to build rootfs images.
 docker build ./examples \
     --build-arg CONFIG=mjpg-streamer \
     --build-arg TARGET_ARCH=aarch64 \
+    --build-arg BR_VERSION=2020.08.2 \
     -t mjpg-streamer-example
 ```
 
@@ -99,5 +118,6 @@ docker build ./examples \
 docker build ./examples \
     --build-arg CONFIG=unbound-dnscrypt \
     --build-arg TARGET_ARCH=aarch64 \
+    --build-arg BR_VERSION=2020.08.2 \
     -t unbound-dnscrypt-example
 ```

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,6 +1,6 @@
 ARG TARGET_ARCH=aarch64
 
-FROM buildroot-base:$TARGET_ARCH-rootfs as buildroot
+FROM buildroot-rootfs-$TARGET_ARCH:$BR_VERSION as buildroot
 
 ARG CONFIG=mjpg-streamer
 


### PR DESCRIPTION
Since the base and rootfs images are fundamentally different
and have different use cases I have moved the rootfs images to
separate arch-specific repos using BR_VERSION as the build tag

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>