### PR TITLE
config.common: unselect busybox

### DIFF
--- a/config.common
+++ b/config.common
@@ -2,8 +2,11 @@
 BR2_TOOLCHAIN_BUILDROOT_MUSL=y
 BR2_KERNEL_HEADERS_4_19=y
 
-# We don't need init inside a container, this also unselects Busybox
+# We don't need init inside a container
 BR2_INIT_NONE=y
+
+# Also unselect busybox
+BR2_PACKAGE_BUSYBOX=n
 
 # We don't need a system shell or ifupdown-scripts
 BR2_SYSTEM_BIN_SH_NONE=y


### PR DESCRIPTION
It turns out, disabling init doesn't actually unselect busybox.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balana.io>