### PR TITLE
Dockerfile: add python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         cpio \
         file \
         locales \
+        python3 \
         rsync \
         unzip \
         wget && \


### PR DESCRIPTION
Buildroot requires host python to build python.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>