### PR TITLE
deploy: adjust multiarch manifest matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,16 @@ This Dockerfile includes 2 stages:
 ## build
 
 ```bash
-# select a buildroot release
-export BR_VERSION=2020.08.2
-
 # build the base image for your host
-docker build . --build-arg BR_VERSION \
+docker build . --build-arg BR_VERSION="2020.08.2" \
     --target base -t buildroot-base
 
-# build the rootfs images for your host
-docker build . --build-arg BR_VERSION \
-    --build-arg TARGET_ARCH=amd64 \
-    -t buildroot-rootfs-amd64:${BR_VERSION}
-
-docker build . --build-arg BR_VERSION \
-    --build-arg TARGET_ARCH=aarch64 \
-    -t buildroot-rootfs-aarch64:${BR_VERSION}
-
-docker build . --build-arg BR_VERSION \
-    --build-arg TARGET_ARCH=armv7hf \
-    -t buildroot-rootfs-armv7hf:${BR_VERSION}
-
-docker build . --build-arg BR_VERSION \
-    --build-arg TARGET_ARCH=armv6hf \
-    -t buildroot-rootfs-armv6hf:${BR_VERSION}
-
-docker build . --build-arg BR_VERSION \
-    --build-arg TARGET_ARCH=rpi \
-    -t buildroot-rootfs-rpi:${BR_VERSION}
+# build an amd64 rootfs image for your host
+docker build . --build-arg BR_VERSION="2020.08.2" \
+    --build-arg TARGET_ARCH=amd64 -t buildroot-rootfs-amd64
 ```
 
-## push
+## deploy
 
 Requires `docker login` to authenticate with your provided `IMAGE_REPO`.
 
@@ -54,10 +34,13 @@ docker buildx create --use --driver docker-container
 # select an image repo, buildroot release, and tag
 export IMAGE_REPO="docker.io/klutchell"
 export BR_VERSION="2020.08.2"
-export IMAGE_TAG="2020.08.2" # or 'latest'
+export IMAGE_TAGS="2020.08.2 latest"
 
-# this part will take all day
+# this part will take all day to build & cache multiarch images
 ./deploy.sh
+
+# then push to docker repo
+./deploy.sh --push
 ```
 
 ## examples

--- a/config/arch/rpi.cfg
+++ b/config/arch/rpi.cfg
@@ -1,1 +1,1 @@
-config.armv6hf
+armv6hf.cfg

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,19 +4,41 @@ set -e
 
 [ -n "${IMAGE_REPO}" ] || IMAGE_REPO="docker.io/klutchell"
 [ -n "${BR_VERSION}" ] || BR_VERSION="2020.08.2"
-[ -n "${IMAGE_TAG}" ] || IMAGE_TAG="${BR_VERSION}"
-[ -n "${HOST_ARCH}" ] || HOST_ARCH="linux/amd64,linux/arm64"
-[ -n "${TARGET_ARCH}" ] || TARGET_ARCH="amd64 aarch64 armv7hf armv6hf rpi"
+[ -n "${IMAGE_TAGS}" ] || IMAGE_TAGS="${BR_VERSION}"
 
-docker buildx build . --platform "${HOST_ARCH}" --build-arg BR_VERSION \
-    --target base \
-    -t ${IMAGE_REPO}/buildroot-base:${IMAGE_TAG} \
-    --push
+image_tags() {
+    for tag in ${IMAGE_TAGS}
+    do
+        echo " -t $1:$tag"
+    done
+}
 
-for arch in ${TARGET_ARCH}
-do
-    docker buildx build . --platform "${HOST_ARCH}" --build-arg BR_VERSION \
-        --build-arg "TARGET_ARCH=${arch}" \
-        -t ${IMAGE_REPO}/buildroot-rootfs-${arch}:${IMAGE_TAG} \
-        --push 
-done
+# shellcheck disable=SC2046
+docker buildx build . --platform "linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6" \
+    --build-arg BR_VERSION --target base \
+    $(image_tags ${IMAGE_REPO}/buildroot-base) "$@"
+
+# shellcheck disable=SC2046
+docker buildx build . --platform "linux/amd64" \
+    --build-arg BR_VERSION --build-arg "TARGET_ARCH=amd64" \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-amd64) "$@"
+
+# shellcheck disable=SC2046
+docker buildx build . --platform "linux/amd64,linux/arm64" \
+    --build-arg BR_VERSION --build-arg "TARGET_ARCH=aarch64" \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-aarch64) "$@"
+
+# shellcheck disable=SC2046
+docker buildx build . --platform "linux/amd64,linux/arm64" \
+    --build-arg BR_VERSION --build-arg "TARGET_ARCH=armv7hf" \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-armv7hf) "$@"
+
+# shellcheck disable=SC2046
+docker buildx build . --platform "linux/amd64,linux/arm64" \
+    --build-arg BR_VERSION --build-arg "TARGET_ARCH=armv6hf" \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-rpi) \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-armv6hf) "$@"
+
+# docker buildx build . --platform "linux/amd64,linux/arm64" \
+#     --build-arg BR_VERSION --build-arg "TARGET_ARCH=rpi" \
+#     -t ${IMAGE_REPO}/buildroot-rootfs-rpi:${IMAGE_TAG} "$@"


### PR DESCRIPTION
Remove arm64 as a host when amd64 is the target. Also
combine rpi and armv6hf for now as they have the same config.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>