### PR TITLE
Dockerfile: build from debian:bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # create a multiarch buildroot image based on
 # https://hub.docker.com/r/buildroot/base
 
-FROM debian:buster as base
+FROM debian:bullseye as base
 
 # hadolint ignore=DL3008
 RUN apt-get update && \


### PR DESCRIPTION
Uses a newer version of GCC and other deps

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>