### PR TITLE
Dockerfile: make source target before build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,5 @@ COPY config/common.cfg \
 
 RUN support/kconfig/merge_config.sh -m common.cfg $TARGET_ARCH.cfg $LIBC.cfg
 
-RUN make olddefconfig && make
+RUN make olddefconfig && make source
+RUN make


### PR DESCRIPTION
Download sources before starting a build. This ensures that all required
sources are available and download successfully, avoiding cases where a
failed download scraps the build partway through.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>