### PR TITLE
Dockerfile: s/TARGET_ARCH/IMAGE_ARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,13 @@ RUN wget -q -O- https://buildroot.org/downloads/buildroot-$BR_VERSION.tar.gz | t
 
 FROM base as rootfs
 
-ARG TARGET_ARCH=aarch64
+ARG IMAGE_ARCH=aarch64
 ARG LIBC=musl
 
 COPY config/common.cfg \
-     config/arch/$TARGET_ARCH.cfg \
+     config/arch/$IMAGE_ARCH.cfg \
      config/libc/$LIBC.cfg ./
 
-RUN support/kconfig/merge_config.sh -m common.cfg $TARGET_ARCH.cfg $LIBC.cfg
+RUN support/kconfig/merge_config.sh -m common.cfg $IMAGE_ARCH.cfg $LIBC.cfg
 
 RUN make olddefconfig && make

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build . --build-arg BR_VERSION="2020.11" \
 
 # build an amd64 rootfs image for your host
 docker build . --build-arg BR_VERSION="2020.11" \
-    --build-arg TARGET_ARCH=amd64 -t buildroot-rootfs-amd64
+    --build-arg IMAGE_ARCH=amd64 -t buildroot-rootfs-amd64
 ```
 
 ## deploy


### PR DESCRIPTION
Rename TARGET_ARCH variable to avoid stomping on Buildroot variables.
This fixes building glibc, and probably other packages.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>