### PR TITLE
Dockerfile: use ROOTFS_ARCH over IMAGE_ARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,14 +39,14 @@ RUN wget -q -O- https://buildroot.org/downloads/buildroot-$BR_VERSION.tar.gz | t
 
 FROM base as rootfs
 
-ARG IMAGE_ARCH=aarch64
+ARG ROOTFS_ARCH=aarch64
 ARG LIBC=musl
 
 COPY config/common.cfg \
-     config/arch/$IMAGE_ARCH.cfg \
+     config/arch/$ROOTFS_ARCH.cfg \
      config/libc/$LIBC.cfg ./
 
-RUN support/kconfig/merge_config.sh -m common.cfg $IMAGE_ARCH.cfg $LIBC.cfg
+RUN support/kconfig/merge_config.sh -m common.cfg $ROOTFS_ARCH.cfg $LIBC.cfg
 
 RUN make olddefconfig && make source
 RUN make

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build . --build-arg BR_VERSION="2020.11" \
 
 # build an amd64 rootfs image for your host
 docker build . --build-arg BR_VERSION="2020.11" \
-    --build-arg IMAGE_ARCH=amd64 -t buildroot-rootfs-amd64
+    --build-arg ROOTFS_ARCH=amd64 -t buildroot-rootfs-amd64
 ```
 
 ## deploy

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,25 +20,28 @@ docker buildx build . --platform "linux/amd64,linux/arm64,linux/arm/v7,linux/arm
 
 # shellcheck disable=SC2046
 docker buildx build . --platform "linux/amd64" \
-    --build-arg BR_VERSION --build-arg "TARGET_ARCH=amd64" \
+    --build-arg BR_VERSION --build-arg "ROOTFS_ARCH=amd64" \
     $(image_tags ${IMAGE_REPO}/buildroot-rootfs-amd64) "$@"
 
 # shellcheck disable=SC2046
 docker buildx build . --platform "linux/amd64,linux/arm64" \
-    --build-arg BR_VERSION --build-arg "TARGET_ARCH=aarch64" \
+    --build-arg BR_VERSION --build-arg "ROOTFS_ARCH=aarch64" \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-arm64) \
     $(image_tags ${IMAGE_REPO}/buildroot-rootfs-aarch64) "$@"
 
 # shellcheck disable=SC2046
 docker buildx build . --platform "linux/amd64,linux/arm64" \
-    --build-arg BR_VERSION --build-arg "TARGET_ARCH=armv7hf" \
+    --build-arg BR_VERSION --build-arg "ROOTFS_ARCH=armv7hf" \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-arm32v7) \
     $(image_tags ${IMAGE_REPO}/buildroot-rootfs-armv7hf) "$@"
 
 # shellcheck disable=SC2046
 docker buildx build . --platform "linux/amd64,linux/arm64" \
-    --build-arg BR_VERSION --build-arg "TARGET_ARCH=armv6hf" \
+    --build-arg BR_VERSION --build-arg "ROOTFS_ARCH=armv6hf" \
     $(image_tags ${IMAGE_REPO}/buildroot-rootfs-rpi) \
+    $(image_tags ${IMAGE_REPO}/buildroot-rootfs-arm32v6) \
     $(image_tags ${IMAGE_REPO}/buildroot-rootfs-armv6hf) "$@"
 
 # docker buildx build . --platform "linux/amd64,linux/arm64" \
-#     --build-arg BR_VERSION --build-arg "TARGET_ARCH=rpi" \
+#     --build-arg BR_VERSION --build-arg "ROOTFS_ARCH=rpi" \
 #     -t ${IMAGE_REPO}/buildroot-rootfs-rpi:${IMAGE_TAG} "$@"


### PR DESCRIPTION
Image arch could be confused with the docker image which has it's own
supported host arch. This should avoid confusion while still not overriding
any buildroot env vars.

Also add balena->golang arch name mapping (eg arch64=arm64)

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>