### PR TITLE
YouTube live streamer (RTMP/H.264)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ ARG BR_VERSION=2020.11
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+COPY patches patches
 RUN wget -q -O- https://buildroot.org/downloads/buildroot-$BR_VERSION.tar.gz | tar xz --strip 1
+RUN shopt -s nullglob; for p in patches/$BR_VERSION/*.patch; do patch -p1 -i $p; done
 
 FROM base as rootfs
 

--- a/app/ffmpeg/Dockerfile
+++ b/app/ffmpeg/Dockerfile
@@ -1,0 +1,32 @@
+ARG IMAGE=buildroot-rootfs-amd64
+# hadolint ignore=DL3006
+FROM $IMAGE as buildroot
+
+COPY . .
+RUN support/kconfig/merge_config.sh -m .config config.pkg
+
+RUN make olddefconfig && make
+
+# hadolint ignore=DL3002
+USER root
+
+RUN mkdir rootfs && \
+    tar xpf output/images/rootfs.tar -C rootfs
+
+FROM scratch
+
+ENV VIDEO_SIZE="1280x720"
+ENV VIDEO_INPUT="/dev/video0"
+ENV INPUT_FORMAT="h264"
+ENV INPUT_OPTIONS="-re"
+ENV OUTPUT_FORMAT="flv"
+ENV OUTPUT_CODEC="copy"
+ENV OUTPUT_OPTIONS=""
+ENV VIDEO_OUTPUT="-f null -"
+
+COPY --from=buildroot /home/br-user/rootfs/ /
+CMD ffmpeg \
+        $INPUT_OPTIONS -f v4l2 -input_format $INPUT_FORMAT -video_size $VIDEO_SIZE -i $VIDEO_INPUT \
+        -f lavfi -i anullsrc \
+        -c:v $OUTPUT_CODEC $OUTPUT_OPTIONS -f $OUTPUT_FORMAT $VIDEO_OUTPUT
+

--- a/app/ffmpeg/config.pkg
+++ b/app/ffmpeg/config.pkg
@@ -1,0 +1,8 @@
+BR2_PACKAGE_FFMPEG=y
+BR2_PACKAGE_FFMPEG_GPL=y
+BR2_PACKAGE_FFMPEG_NONFREE=y
+BR2_PACKAGE_LAME=y # encode audio as mp3
+BR2_PACKAGE_LIBV4L=y # used by libavdevice to access v4l2 devices
+BR2_PACKAGE_X264=y # useful if you want to re-encode at a lower bitrate
+BR2_SYSTEM_BIN_SH_BUSYBOX=y # needed for args
+

--- a/patches/2020.11/0001-package-ffmpeg-enable-libv4l2-when-selected.patch
+++ b/patches/2020.11/0001-package-ffmpeg-enable-libv4l2-when-selected.patch
@@ -1,0 +1,31 @@
+From 399e714ce0acf98a7e3efee8c836c1bcd7c899fd Mon Sep 17 00:00:00 2001
+From: Joseph Kogut <joseph.kogut@gmail.com>
+Date: Wed, 9 Dec 2020 10:13:03 -0800
+Subject: [PATCH] package/ffmpeg: enable libv4l2 when selected
+
+Signed-off-by: Joseph Kogut <joseph.kogut@gmail.com>
+---
+ package/ffmpeg/ffmpeg.mk | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/package/ffmpeg/ffmpeg.mk b/package/ffmpeg/ffmpeg.mk
+index 6b7437411c..fd4a8ab1c4 100644
+--- a/package/ffmpeg/ffmpeg.mk
++++ b/package/ffmpeg/ffmpeg.mk
+@@ -84,6 +84,13 @@ else
+ FFMPEG_CONF_OPTS += --disable-ffplay
+ endif
+ 
++ifeq ($(BR2_PACKAGE_LIBV4L),y)
++FFMPEG_DEPENDENCIES += libv4l
++FFMPEG_CONF_OPTS += --enable-libv4l2
++else
++FFMPEG_CONF_OPTS += --disable-libv4l2
++endif
++
+ ifeq ($(BR2_PACKAGE_FFMPEG_AVRESAMPLE),y)
+ FFMPEG_CONF_OPTS += --enable-avresample
+ else
+-- 
+2.29.2
+


### PR DESCRIPTION
This project highlights the utility of combining a simple rootfs with an application or two, along with a CMD and a few variables.

Using FFmpeg, we can stream H.264 video live to YouTube simply by overriding the `VIDEO_OUTPUT` variable with our RTMP URL and stream key. Interestingly, we can actually stream video directly from the camera already encoded, so the CPU usage is very low, around 5% on the Pi 4 for 720p.

I'd like to facilitate applications like this *somehow*, but I'm not sure this approach is worth merging. For one, there are many other uses of FFmpeg besides live streaming. Two, this approach requires another Dockerfile, which is largely a copy of the one from `app/`. I think it would be interesting if we could combine a BR config with the application variables and CMD for an app, and build and deploy that app on Balena. Possibly generating a Dockerfile using the one from `app/` as a template? Three, I think I agree that this repo is not the best place to be adding a repository of applications.